### PR TITLE
Role-aware executor signer selection in simulateWorkflow

### DIFF
--- a/src/integrations/workflowSDK.ts
+++ b/src/integrations/workflowSDK.ts
@@ -136,21 +136,31 @@ export class WorkflowSDKIntegration {
   ): Promise<SimulationResult> {
     logger.info(`Simulating workflow execution for ${ipfsHash}`);
     try {
+      const config = getConfig();
+
+      // Attesters (API_ONLY=true) simulate as the performer's address (EXECUTOR_ADDRESS)
+      // to reproduce the performer's userOp - they must NOT sign with their own key
+      // even if EXECUTOR_PRIVATE_KEY is present in the environment.
+      // Performers (API_ONLY=false) need the real private key so the simulated userOp
+      // carries a valid signature - an empty account produces a dummy signature
+      // that fails on-chain with AA24.
       let executor: Signer;
-      if (this.config.executorAddress != "") {
+      if (config.apiOnly && this.config.executorAddress != "") {
         logger.info(`Using executor address: ${this.config.executorAddress}`);
         executor = addressToEmptyAccount(this.config.executorAddress as `0x${string}`);
       } else if (this.config.executorPrivateKey != "") {
         executor = privateKeyToAccount(this.config.executorPrivateKey as `0x${string}`);
+      } else if (this.config.executorAddress != "") {
+        logger.info(`Using executor address: ${this.config.executorAddress}`);
+        executor = addressToEmptyAccount(this.config.executorAddress as `0x${string}`);
       } else {
         throw new Error('Executor address or private key is not defined in environment variables');
       }
 
       // Load workflow to get owner address for whitelist check
       const workflowData = await this.loadWorkflowFromIpfs(ipfsHash);
-      
+
       // Check if owner is whitelisted for WASM execution
-      const config = getConfig();
       let wasmClient: any = undefined;
       let db: Database | undefined;
       


### PR DESCRIPTION
## Problem

`simulateWorkflow` builds the executor signer preferring `EXECUTOR_ADDRESS` (→ `addressToEmptyAccount`, cannot sign, produces a dummy ECDSA stub) over `EXECUTOR_PRIVATE_KEY` (→ real signer). On a **performer** node with both vars set, the Othentic flow embeds the simulation's userOp signature into the on-chain task data (`worker.ts:680`), so the dummy stub fails on-chain with **AA24**. During stage v3 E2E this had to be hot-patched on the running containers by swapping the conditional.

A blind swap is not safe to upstream: the operator-facing **attester** compose (ditto-runner-node) sets `EXECUTOR_ADDRESS` to the canonical performer address for simulation parity *and* loads the operator's own `EXECUTOR_PRIVATE_KEY` into the container env via `env_file`. A swap would make every external attester simulate as its own operator address instead of the performer's, breaking parity with the performer's proof.

## Fix

Gate the address preference on the existing `API_ONLY` role flag (`config.apiOnly`):

1. `API_ONLY=true` + `EXECUTOR_ADDRESS` set → empty account at the performer's address (**attester — unchanged behavior**)
2. `EXECUTOR_PRIVATE_KEY` set → real signer (**performer fix**)
3. `EXECUTOR_ADDRESS` fallback → empty account (unchanged for key-less nodes)
4. neither → throw (unchanged)

Behavior is identical to master for every attester configuration and for any node with only one of the two vars set. The only changed case is `API_ONLY != true` with both vars set — which is exactly the performer bug.

## Verification

- `npm run build` (tsc) passes.
- `npm test`: 14 failed / 14 passed — verified via `git stash` that clean master produces the **exact same 14 failures** (environment-dependent tests needing live RPC/IPFS config). No test covers executor selection.
- Attester path (`validateApi.ts:289`) compares only `callData` + `nonce` against the performer's packed userOp (`validateApi.ts:369-370`), never the signature — confirmed empty-account simulation remains sufficient there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)